### PR TITLE
safe import

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
 		for (std::size_t j = 0; j < size[1]; ++j)
 			grid2_naive_transposition[j][i] = grid2D[i][j];
 
-	std::cout << "\nNaive transposition in " << std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - start).count() << " ns." << std::endl;
+	std::cout << "\nNaive transposition in " << std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - start).count() << " ns.\n";
 
 	std::cout << "Transposition (naive):\n";
 	for (std::size_t i = 0; i < size[0]; ++i) {
@@ -61,8 +61,9 @@ int main(int argc, char *argv[])
 
 	auto grid2D_permuted = grid2D.permute(order);
 
-	std::cout << "\nDope Transposition in " << std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - start).count() << " ns." << std::endl;
+	std::cout << "\nDope Transposition in " << std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - start).count() << " ns.\n";
 
+	std::cout << "Transposition (dope):\n";
 	for (std::size_t i = 0; i < size[0]; ++i) {
 		auto grid_row = grid2D_permuted[i];
 		for (std::size_t j = 0; j < size[1]; ++j)
@@ -80,6 +81,33 @@ int main(int argc, char *argv[])
 	big_grid.permute(new_order);
 
 	std::cout << "\nBig grid (10 side length X 10 dimensions) permuted in " << std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - start).count() << " ns." << std::endl;
+
+
+	// safe import of overlapping window
+	auto upper_left_window = grid2D.window({0, 0}, {5, 5});
+	auto lower_right_window = grid2D.window({3, 3}, {5, 5});
+	lower_right_window.safeImport(upper_left_window);
+	std::cout << "\n\nUpper left 5x5 window safely imported into 5x5 window at (3,3):\n";
+	for (std::size_t i = 0; i < size[0]; ++i) {
+		auto grid_row = grid2D_permuted[i];
+		for (std::size_t j = 0; j < size[1]; ++j)
+			std::cout << grid_row[j] << '\t';
+		std::cout << '\n';
+	}
+	for (std::size_t i = 0; i < size[0]; ++i) {
+		DopeVector<std::size_t, 1> grid_row = grid2D[i];
+		for (std::size_t j = 0; j < size[1]; ++j)
+			grid_row[j] = i * size[0] + j;
+	}
+	lower_right_window.import(upper_left_window);
+	std::cout << "\nUpper left 5x5 window NON-safely imported into 5x5 window at (3,3):\n";
+	for (std::size_t i = 0; i < size[0]; ++i) {
+		auto grid_row = grid2D_permuted[i];
+		for (std::size_t j = 0; j < size[1]; ++j)
+			std::cout << grid_row[j] << '\t';
+		std::cout << '\n';
+	}
+	std::cout << "Compare elements at (6,6). This is due to the fact that dope vectors act on shared memory.\n" << std::endl;
 
 	return 0;
 }

--- a/include/DopeVector/DopeVector.hpp
+++ b/include/DopeVector/DopeVector.hpp
@@ -132,8 +132,21 @@ namespace dope {
 		/**
 		 *    @brief Copies all single elements from o to this matrix.
 		 *    @param o                  The matrix to copy from.
+		 *    @note This does not guarantee consistency in case of (partial)
+		 *          memory overlap. If you can not garantee it yourself, then
+		 *          use safeImport.
 		 */
 		virtual inline void import(const DopeVector &o);
+
+		/**
+		 *    @brief Copies all single elements from o to this matrix in a
+		 *           consistent way.
+		 *    @param o                  The matrix to copy from.
+		 *    @note To garantee consistency, this method allocates temporary
+		 *          data to copy o's into, and then to copy this' from. So it is
+		 *          slower then import.
+		 */
+		inline void safeImport(const DopeVector &o);
 
 		////////////////////////////////////////////////////////////////////////
 
@@ -257,7 +270,7 @@ namespace dope {
 		 *    @param size               The sizes of the window.
 		 *    @param w                  The output sub-matrix.
 		 */
-		inline void window(const IndexD &start, IndexD &size, DopeVector &w) const;
+		inline void window(const IndexD &start, const IndexD &size, DopeVector &w) const;
 
 		/**
 		 *    @brief Extracts a D-dimensional window from this matrix.
@@ -472,8 +485,21 @@ namespace dope {
 		/**
 		 *    @brief Copies all single elements from o to this matrix.
 		 *    @param o                  The matrix to copy from.
+		 *    @note This does not guarantee consistency in case of (partial)
+		 *          memory overlap. If you can not garantee it yourself, then
+		 *          use safeImport.
 		 */
 		virtual inline void import(const DopeVector &o);
+
+		/**
+		 *    @brief Copies all single elements from o to this matrix in a
+		 *           consistent way.
+		 *    @param o                  The matrix to copy from.
+		 *    @note To garantee consistency, this method allocates temporary
+		 *          data to copy o's into, and then to copy this' from. So it is
+		 *          slower then import.
+		 */
+		inline void safeImport(const DopeVector &o);
 
 		////////////////////////////////////////////////////////////////////////
 

--- a/include/DopeVector/internal/inlines/DopeVector.inl
+++ b/include/DopeVector/internal/inlines/DopeVector.inl
@@ -9,6 +9,7 @@
 // email: maurizio.kovacic@gmail.com
 
 #include <DopeVector/DopeVector.hpp>
+#include <memory>
 
 namespace dope {
 
@@ -78,7 +79,7 @@ namespace dope {
 	}
 
 	template < typename T, SizeType Dimension >
-	inline void DopeVector<T, Dimension>::import(const DopeVector &o)
+	inline void DopeVector<T, Dimension>::import(const DopeVector<T, Dimension> &o)
 	{
 		if (&o == this)
 			return;
@@ -86,6 +87,19 @@ namespace dope {
 			throw std::out_of_range("Matrixes do not have same size.");
 		for (SizeType i = 0; i < _size[0]; ++i)
 			operator[](i).import(o[i]);
+	}
+
+	template < typename T, SizeType Dimension >
+	inline void DopeVector<T, Dimension>::safeImport(const DopeVector<T, Dimension> &o)
+	{
+		if (&o == this)
+			return;
+		if (allSizes() != o.allSizes())
+			throw std::out_of_range("Matrixes do not have same size.");
+		std::unique_ptr<T[]> tempPtr(new T[o.size()]);
+		DopeVector<T, Dimension> tmpDopeVector(tempPtr.get(), 0, o.allSizes());
+		tmpDopeVector.import(o);
+		import(tmpDopeVector);
 	}
 
 	////////////////////////////////////////////////////////////////////////
@@ -234,7 +248,7 @@ namespace dope {
 	}
 
 	template < typename T, SizeType Dimension >
-	inline void DopeVector<T, Dimension>::window(const IndexD &start, IndexD &size, DopeVector<T, Dimension> &w) const
+	inline void DopeVector<T, Dimension>::window(const IndexD &start, const IndexD &size, DopeVector<T, Dimension> &w) const
 	{
 		for (SizeType d = 0; d < D; ++d) {
 			if (start[d] >= _size[d]) {
@@ -416,6 +430,19 @@ namespace dope {
 			throw std::out_of_range("Matrixes do not have same size.");
 		for (SizeType i = 0; i < _size[0]; ++i)
 			at(i) = o.at(i);
+	}
+
+	template < typename T >
+	inline void DopeVector<T, 1>::safeImport(const DopeVector<T, 1> &o)
+	{
+		if (&o == this)
+			return;
+		if (sizeAt(0) != o.sizeAt(0))
+			throw std::out_of_range("Matrixes do not have same size.");
+		std::unique_ptr<T[]> tempPtr(new T[o.size()]);
+		DopeVector<T, 1> tmpDopeVector(tempPtr.get(), 0, o.allSizes());
+		tmpDopeVector.import(o);
+		import(tmpDopeVector);
 	}
 
 	////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Old import is not enough to avoid collision with overlapping data. New safeImport, made on top of old import, first makes a temporary copy of the data.